### PR TITLE
Add extension methods, test, and readme

### DIFF
--- a/HiperServiceResultHandler.Test.Runner/DirectServiceTester.cs
+++ b/HiperServiceResultHandler.Test.Runner/DirectServiceTester.cs
@@ -1,0 +1,79 @@
+namespace HiperServiceResultHandler.Test.Runner
+{
+    public class DirectServiceTester
+    {
+        [Fact]
+        public async Task TestGetOk()
+        {
+            var http = new HttpClient();
+            var s = await http.GetAsync<string>("http://localhost:5046/getOk");
+            Assert.Equal("Everything is fine", s);
+        }
+
+        [Fact]
+        public async Task TestGetFailure()
+        {
+            var http = new HttpClient();
+            var exception = await Assert.ThrowsAsync<ServiceException>(() =>
+            {
+                return http.GetAsync<string>("http://localhost:5046/getFailure");
+            });
+            Assert.Equal("User message error", exception.UserMessage);
+            Assert.Equal("USER_MESSAGE_CODE", exception.UserMessageCode);
+            Assert.Equal("Internal message", exception.Message);
+            Assert.Equal(1234, exception.ErrorCode);
+        }
+
+        [Fact]
+        public async Task TestPostFailure()
+        {
+            var http = new HttpClient();
+            var exception = await Assert.ThrowsAsync<ServiceException>(() =>
+            {
+                return http.PostAsJsonAsync<string>("http://localhost:5046/postFailure", new
+                {
+                    ParamA = "Something",
+                    ParamB = true,
+                });
+            });
+            Assert.Equal("User message error", exception.UserMessage);
+            Assert.Equal("USER_MESSAGE_CODE", exception.UserMessageCode);
+            Assert.Equal("Internal message", exception.Message);
+            Assert.Equal(1234, exception.ErrorCode);
+        }
+
+        [Fact]
+        public async Task TestPostFailureParameterA()
+        {
+            var http = new HttpClient();
+            var exception = await Assert.ThrowsAsync<ServiceException>(() =>
+            {
+                return http.PostAsJsonAsync<string>("http://localhost:5046/postFailure", new
+                {
+                    ParamB = true,
+                });
+            });
+            Assert.Equal("Parameter empty", exception.UserMessage);
+            Assert.Equal("PARAM_INVALID", exception.UserMessageCode);
+            Assert.Equal("There was an issue with parameter A", exception.Message);
+            Assert.Equal(2345, exception.ErrorCode);
+        }
+
+        [Fact]
+        public async Task TestPostFailureParameterB()
+        {
+            var http = new HttpClient();
+            var exception = await Assert.ThrowsAsync<ServiceException>(() =>
+            {
+                return http.PostAsJsonAsync<string>("http://localhost:5046/postFailure", new
+                {
+                    ParamA = "Something",
+                });
+            });
+            Assert.Equal("Parameter false", exception.UserMessage);
+            Assert.Equal("PARAM_INVALID", exception.UserMessageCode);
+            Assert.Equal("There was an issue with parameter B", exception.Message);
+            Assert.Equal(2345, exception.ErrorCode);
+        }
+    }
+}

--- a/HiperServiceResultHandler.Test.Runner/HiperServiceResultHandler.Test.Runner.csproj
+++ b/HiperServiceResultHandler.Test.Runner/HiperServiceResultHandler.Test.Runner.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HiperServiceResultHandler\HiperServiceResultHandler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HiperServiceResultHandler.Test.Runner/PublicServerTester.cs
+++ b/HiperServiceResultHandler.Test.Runner/PublicServerTester.cs
@@ -1,0 +1,32 @@
+using HiperServiceResultHandler.Models;
+using Newtonsoft.Json;
+
+namespace HiperServiceResultHandler.Test.Runner
+{
+    public class PublicServerTester
+    {
+        [Fact]
+        public async Task TestGetOk()
+        {
+            var http = new HttpClient();
+            var s = await http.GetStringAsync("http://localhost:5045/getOk");
+            Assert.Equal("Everything is fine", s);
+        }
+
+        [Fact]
+        public async Task TestGetFailure()
+        {
+            var http = new HttpClient();
+            var response = await http.SendAsync(new HttpRequestMessage(HttpMethod.Get, "http://localhost:5045/getFailure"));
+            Assert.Equal(System.Net.HttpStatusCode.InternalServerError, response.StatusCode);
+
+            var s = await response.Content.ReadAsStringAsync();
+            var error = JsonConvert.DeserializeObject<ApiError>(s);
+            Assert.False(error.IsSuccessful);
+            Assert.Equal(500, error.StatusCode);
+            Assert.Equal("User message error", error.Message);
+            Assert.Equal("USER_MESSAGE_CODE", error.MessageCode);
+            Assert.Null(error.Exception); // If not in development mode
+        }
+    }
+}

--- a/HiperServiceResultHandler.Test.Runner/Usings.cs
+++ b/HiperServiceResultHandler.Test.Runner/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/HiperServiceResultHandler.Test.Server/HiperServiceResultHandler.Test.Server.csproj
+++ b/HiperServiceResultHandler.Test.Server/HiperServiceResultHandler.Test.Server.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HiperServiceResultHandler\HiperServiceResultHandler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HiperServiceResultHandler.Test.Server/Program.cs
+++ b/HiperServiceResultHandler.Test.Server/Program.cs
@@ -1,0 +1,53 @@
+using HiperServiceResultHandler;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+app.ConfigurePublicServiceExceptionHandler(new PublicExceptionMiddleware.Options { DevelopmentMode = false });
+
+app.Use(async (context, next) =>
+{
+    context.Request.EnableBuffering();
+    await next();
+});
+
+app.MapGet("/getOk", async (HttpContext context) =>
+{
+    await DebugRequest(context.Request);
+
+    var http = new HttpClient();
+    var s = await http.GetAsync<string>("http://localhost:5046/getOk");
+
+    return s;
+});
+
+app.MapGet("/getFailure", async (HttpContext context) =>
+{
+    await DebugRequest(context.Request);
+
+    var http = new HttpClient();
+    var s = await http.GetAsync<string>("http://localhost:5046/getFailure");
+
+    // This will fail and generate an ApiError response
+
+    return s;
+});
+
+app.Run();
+
+async Task DebugRequest(HttpRequest request)
+{
+    Console.WriteLine($"HTTP {request.Method} {request.Path}");
+    foreach (var h in request.Headers)
+    {
+        Console.WriteLine($"{h.Key}: {h.Value}");
+    }
+    if (request.ContentLength.GetValueOrDefault(0) > 0)
+    {
+        request.Body.Position = 0;
+        using var sr = new StreamReader(request.Body);
+        var body = await sr.ReadToEndAsync();
+        Console.WriteLine(body);
+    }
+    Console.WriteLine();
+}

--- a/HiperServiceResultHandler.Test.Server/Properties/launchSettings.json
+++ b/HiperServiceResultHandler.Test.Server/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Test server runner": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5045",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/HiperServiceResultHandler.Test.Server/appsettings.Development.json
+++ b/HiperServiceResultHandler.Test.Server/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/HiperServiceResultHandler.Test.Server/appsettings.json
+++ b/HiperServiceResultHandler.Test.Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/HiperServiceResultHandler.Test.Service/HiperServiceResultHandler.Test.Service.csproj
+++ b/HiperServiceResultHandler.Test.Service/HiperServiceResultHandler.Test.Service.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HiperServiceResultHandler\HiperServiceResultHandler.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HiperServiceResultHandler.Test.Service/Program.cs
+++ b/HiperServiceResultHandler.Test.Service/Program.cs
@@ -1,0 +1,74 @@
+using HiperServiceResultHandler;
+using HiperServiceResultHandler.Models;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+app.ConfigureServiceExceptionHandler();
+
+app.Use(async (context, next) =>
+{
+    context.Request.EnableBuffering();
+    await next();
+});
+
+app.MapGet("/getOk", async (HttpContext context) =>
+{
+    await DebugRequest(context.Request);
+
+    return new ApiResultMessage<string>
+    {
+        Data = "Everything is fine",
+        IsSuccessful = true,
+    };
+});
+
+app.MapGet("/getFailure", async (HttpContext context) =>
+{
+    await DebugRequest(context.Request);
+
+    throw new ServiceException("User message error", 1234, "USER_MESSAGE_CODE", "Internal message");
+});
+
+app.MapPost("/postFailure", async (HttpContext context, [FromBody] PostParameters parms) =>
+{
+    await DebugRequest(context.Request);
+
+    if (string.IsNullOrEmpty(parms.ParamA))
+    {
+        throw new ServiceException("Parameter empty", 2345, "PARAM_INVALID", "There was an issue with parameter A");
+    }
+    if (!parms.ParamB)
+    {
+        throw new ServiceException("Parameter false", 2345, "PARAM_INVALID", "There was an issue with parameter B");
+    }
+
+    // No rest for the wicked
+    throw new ServiceException("User message error", 1234, "USER_MESSAGE_CODE", "Internal message");
+});
+
+app.Run();
+
+async Task DebugRequest(HttpRequest request)
+{
+    Console.WriteLine($"HTTP {request.Method} {request.Path}");
+    foreach(var h in request.Headers)
+    {
+        Console.WriteLine($"{h.Key}: {h.Value}");
+    }
+    if(request.ContentLength.GetValueOrDefault(0) > 0)
+    {
+        request.Body.Position = 0;
+        using var sr = new StreamReader(request.Body);
+        var body = await sr.ReadToEndAsync();
+        Console.WriteLine(body);
+    }
+    Console.WriteLine();
+}
+
+class PostParameters
+{
+    public string ParamA { get; set; }
+    public bool ParamB { get; set; }
+}

--- a/HiperServiceResultHandler.Test.Service/Properties/launchSettings.json
+++ b/HiperServiceResultHandler.Test.Service/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Test service runner": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5046",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/HiperServiceResultHandler.Test.Service/appsettings.Development.json
+++ b/HiperServiceResultHandler.Test.Service/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/HiperServiceResultHandler.Test.Service/appsettings.json
+++ b/HiperServiceResultHandler.Test.Service/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/HiperServiceResultHandler.sln
+++ b/HiperServiceResultHandler.sln
@@ -1,9 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30717.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HiperServiceResultHandler", "HiperServiceResultHandler\HiperServiceResultHandler.csproj", "{C5DC41F6-1D36-4C63-85FC-D1219A836A19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiperServiceResultHandler.Test.Server", "HiperServiceResultHandler.Test.Server\HiperServiceResultHandler.Test.Server.csproj", "{8ED0DED1-C70B-4965-A6D9-929517FAA600}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiperServiceResultHandler.Test.Runner", "HiperServiceResultHandler.Test.Runner\HiperServiceResultHandler.Test.Runner.csproj", "{70C1B37D-44C6-47AF-8C31-5BD12460532A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiperServiceResultHandler.Test.Service", "HiperServiceResultHandler.Test.Service\HiperServiceResultHandler.Test.Service.csproj", "{3B87BD1A-1AC2-4025-ABA7-7BDD4D588AE5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +21,18 @@ Global
 		{C5DC41F6-1D36-4C63-85FC-D1219A836A19}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5DC41F6-1D36-4C63-85FC-D1219A836A19}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5DC41F6-1D36-4C63-85FC-D1219A836A19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8ED0DED1-C70B-4965-A6D9-929517FAA600}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8ED0DED1-C70B-4965-A6D9-929517FAA600}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8ED0DED1-C70B-4965-A6D9-929517FAA600}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8ED0DED1-C70B-4965-A6D9-929517FAA600}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70C1B37D-44C6-47AF-8C31-5BD12460532A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70C1B37D-44C6-47AF-8C31-5BD12460532A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70C1B37D-44C6-47AF-8C31-5BD12460532A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70C1B37D-44C6-47AF-8C31-5BD12460532A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B87BD1A-1AC2-4025-ABA7-7BDD4D588AE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B87BD1A-1AC2-4025-ABA7-7BDD4D588AE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B87BD1A-1AC2-4025-ABA7-7BDD4D588AE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B87BD1A-1AC2-4025-ABA7-7BDD4D588AE5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HiperServiceResultHandler/HttpClientExtensions.cs
+++ b/HiperServiceResultHandler/HttpClientExtensions.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -148,9 +149,17 @@ namespace HiperServiceResultHandler
         /// <typeparam name="T">Object class to deserialize.</typeparam>
         public static async Task<T> ReadAsJsonAsync<T>(this HttpContent content)
         {
-            // TODO: do stream deserialization
-            var dataAsString = await content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<T>(dataAsString);
+            using (var stream = await content.ReadAsStreamAsync())
+            {
+                using (var reader = new StreamReader(stream))
+                {
+                    using (var jsonReader = new JsonTextReader(reader))
+                    {
+                        var serializer = JsonSerializer.Create(SerializerSettings);
+                        return serializer.Deserialize<T>(jsonReader);
+                    }
+                }
+            }
         }
     }
 }

--- a/HiperServiceResultHandler/HttpClientExtensions.cs
+++ b/HiperServiceResultHandler/HttpClientExtensions.cs
@@ -27,11 +27,13 @@ namespace HiperServiceResultHandler
 
         private static readonly ProductInfoHeaderValue HiperUserAgentHeader;
 
-        private static readonly JsonSerializerSettings DefaultSerializerSettings = new JsonSerializerSettings
+        public static readonly JsonSerializerSettings DefaultSerializerSettings = new JsonSerializerSettings
         {
-            ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Formatting = Formatting.Indented,
         };
+
+        public static JsonSerializerSettings SerializerSettings { get; set; } = DefaultSerializerSettings;
 
         private static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
 
@@ -115,7 +117,7 @@ namespace HiperServiceResultHandler
 
         private static HttpContent CreateRequestContent(object data)
         {
-            var dataAsString = data == null ? "{}" : JsonConvert.SerializeObject(data, DefaultSerializerSettings);
+            var dataAsString = data == null ? "{}" : JsonConvert.SerializeObject(data, SerializerSettings);
 
             var content = new StringContent(dataAsString);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");

--- a/HiperServiceResultHandler/HttpClientExtensions.cs
+++ b/HiperServiceResultHandler/HttpClientExtensions.cs
@@ -1,0 +1,154 @@
+﻿using HiperServiceResultHandler.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace HiperServiceResultHandler
+{
+    public static class HttpClientExtensions
+    {
+        static HttpClientExtensions()
+        {
+            try
+            {
+                HiperUserAgentHeader = new ProductInfoHeaderValue("HiperServiceClient", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+            }
+            catch (Exception)
+            {
+                HiperUserAgentHeader = new ProductInfoHeaderValue("HiperServiceClient", "1.0");
+            }
+        }
+
+        private static readonly ProductInfoHeaderValue HiperUserAgentHeader;
+
+        private static readonly JsonSerializerSettings DefaultSerializerSettings = new JsonSerializerSettings
+        {
+            ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
+            Formatting = Formatting.Indented,
+        };
+
+        private static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
+
+        public static void Replace<T>(this HttpHeaderValueCollection<T> collection, T newValue) where T : class
+        {
+            if(collection != null)
+            {
+                collection.Clear();
+                collection.Add(newValue);
+            }
+        }
+
+        /// <summary>
+        /// Send GET request and process service response with query string parameters.
+        /// </summary>
+        public static Task<R> GetAsync<R>(this HttpClient httpClient, string url, IDictionary<string, string> queryParams)
+        {
+            return httpClient.GetAsync<R>(QueryHelpers.AddQueryString(url, queryParams));
+        }
+
+        /// <summary>
+        /// Send GET request and process service response.
+        /// </summary>
+        public static Task<R> GetAsync<R>(this HttpClient httpClient, string url)
+        {
+            return httpClient.SendAsync<R>(HttpMethod.Get, url);
+        }
+
+        /// <summary>
+        /// Send PUT request with optional data payload and process service response.
+        /// </summary>
+        public static Task<R> PutAsJsonAsync<R>(this HttpClient httpClient, string url, object data = null)
+        {
+            return httpClient.SendAsync<R>(HttpMethod.Put, url, CreateRequestContent(data));
+        }
+
+        /// <summary>
+        /// Send POST request with optional data payload and process service response.
+        /// </summary>
+        public static Task<R> PostAsJsonAsync<R>(this HttpClient httpClient, string url, object data = null)
+        {
+            return httpClient.SendAsync<R>(HttpMethod.Post, url, CreateRequestContent(data));
+        }
+
+        /// <summary>
+        /// Send PATCH request with optional data payload and process service response.
+        /// </summary>
+        public static Task<R> PatchAsJsonAsync<R>(this HttpClient httpClient, string url, object data = null)
+        {
+            return httpClient.SendAsync<R>(PatchMethod, url, CreateRequestContent(data));
+        }
+
+        /// <summary>
+        /// Send DELETE request with optional data payload and process service response.
+        /// </summary>
+        public static Task<R> DeleteAsync<R>(this HttpClient httpClient, string url, object data = null)
+        {
+            return httpClient.SendAsync<R>(HttpMethod.Delete, url);
+        }
+
+        /// <summary>
+        /// Send generic message and process service response.
+        /// </summary>
+        /// <typeparam name="R">Object class of service response.</typeparam>
+        /// <param name="method">The HTTP method.</param>
+        /// <param name="url">The request URI.</param>
+        /// <param name="body">The optional HTTP content sent through the request.</param>
+        public static async Task<R> SendAsync<R>(this HttpClient httpClient, HttpMethod method, string url, HttpContent body = null)
+        {
+            var request = new HttpRequestMessage(method, url);
+            request.Headers.UserAgent.Replace(HiperUserAgentHeader);
+            if(body != null)
+            {
+                request.Content = body;
+            }
+
+            var response = await httpClient.SendAsync(request);
+
+            return await ReadResponse<R>(response);
+        }
+
+        private static HttpContent CreateRequestContent(object data)
+        {
+            var dataAsString = data == null ? "{}" : JsonConvert.SerializeObject(data, DefaultSerializerSettings);
+
+            var content = new StringContent(dataAsString);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            return content;
+        }
+
+        private static async Task<R> ReadResponse<R>(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception("Unexpected service error");
+            }
+
+            var result = await response.Content.ReadAsJsonAsync<ApiResultMessage<R>>();
+            if (result.IsSuccessful)
+            {
+                return result.Data;
+            }
+            else
+            {
+                throw new ServiceException(result.UserMessage, result.ErrorCode, result.UserMessageCode, result.Message);
+            }
+        }
+
+        /// <summary>
+        /// Reads contents from a <see cref="HttpContent"/> instance and deserializes it as a JSON object.
+        /// </summary>
+        /// <typeparam name="T">Object class to deserialize.</typeparam>
+        public static async Task<T> ReadAsJsonAsync<T>(this HttpContent content)
+        {
+            // TODO: do stream deserialization
+            var dataAsString = await content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(dataAsString);
+        }
+    }
+}

--- a/HiperServiceResultHandler/Models/ApiError.cs
+++ b/HiperServiceResultHandler/Models/ApiError.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Net;
+
+namespace HiperServiceResultHandler.Models
+{
+    public class ApiError
+    {
+        public bool IsSuccessful { get; set; } = false;
+
+        public int StatusCode { get; set; } = (int)HttpStatusCode.InternalServerError;
+
+        public string Message { get; set; }
+
+        public string MessageCode { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string Exception { get; set; }
+
+        public ApiError()
+        {
+            // No-op for deserialization
+        }
+
+        public ApiError(int statusCode, string message, string messageCode, Exception exception = null)
+        {
+            StatusCode = statusCode;
+            Message = message;
+            MessageCode = messageCode;
+            Exception = exception?.ToString();
+        }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/HiperServiceResultHandler/Models/ApiResultMessage.cs
+++ b/HiperServiceResultHandler/Models/ApiResultMessage.cs
@@ -5,26 +5,41 @@ namespace HiperServiceResultHandler.Models
     public class ApiResultMessage
     {
         public object Data { get; set; }
+
         public bool IsSuccessful { get; set; }
+
         public string UserMessage { get; set; }
+
         public string UserMessageCode { get; set; }
+
         public string Message { get; set; }
+
         public int ErrorCode { get; set; }
+
         public string Exception { get; set; }
+
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this);
         }
     }
+
     public class ApiResultMessage<T>
     {
         public T Data { get; set; }
+
         public bool IsSuccessful { get; set; }
+
         public string UserMessage { get; set; }
+
         public string UserMessageCode { get; set; }
+
         public string Message { get; set; }
+
         public int ErrorCode { get; set; }
+
         public string Exception { get; set; }
+
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this);

--- a/HiperServiceResultHandler/PublicExceptionMiddleware.cs
+++ b/HiperServiceResultHandler/PublicExceptionMiddleware.cs
@@ -1,0 +1,94 @@
+﻿using HiperServiceResultHandler.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace HiperServiceResultHandler
+{
+    /// <summary>
+    /// Exception middleware to use in the ASP.NET pipeline in order to encode exceptions
+    /// in an instance of <see cref="ApiError"/>.
+    /// </summary>
+    public class PublicExceptionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<PublicExceptionMiddleware> _logger;
+        private readonly Options _options;
+
+        public class Options
+        {
+            public bool DevelopmentMode { get; set; } = false;
+        }
+
+        public PublicExceptionMiddleware(RequestDelegate next, ILogger<PublicExceptionMiddleware> logger, Options options = null)
+        {
+            _next = next;
+            _logger = logger;
+            _options = options ?? new Options();
+        }
+
+        public async Task InvokeAsync(HttpContext httpContext)
+        {
+            try
+            {
+                await _next(httpContext);
+            }
+            catch (ServiceException exc)
+            {
+                _logger.LogError(exc, "Unhandled service exception, user message: {0}, message: {1}", exc.UserMessage, exc.Message);
+                await HandleServiceExceptionAsync(httpContext, exc);
+            }
+            catch (Exception ex)
+            {
+                if (httpContext.RequestAborted.IsCancellationRequested)
+                {
+                    _logger.LogWarning(ex, "Request aborted: {0}", ex.Message);
+                    return;
+                }
+                _logger.LogError(ex, "Unhandled error: {0}", ex.Message);
+                await HandleExceptionAsync(httpContext, ex);
+            }
+        }
+
+        private Task HandleServiceExceptionAsync(HttpContext context, ServiceException exception)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+            return context.Response.WriteAsync(
+                new ApiError(
+                    (int)HttpStatusCode.InternalServerError,
+                    exception.UserMessage ?? exception.Message,
+                    exception.UserMessageCode, 
+                    _options.DevelopmentMode ? exception : null
+                ).ToString()
+            );
+        }
+
+        private Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+            return context.Response.WriteAsync(
+                new ApiError(
+                    (int)HttpStatusCode.InternalServerError,
+                    "Internal server error",
+                    null,
+                    _options.DevelopmentMode ? exception : null
+                ).ToString()
+            );
+        }
+    }
+
+    public static class ConfigurePublicExceptionHandler
+    {
+        public static void ConfigurePublicServiceExceptionHandler(this IApplicationBuilder app, PublicExceptionMiddleware.Options options)
+        {
+            app.UseMiddleware<PublicExceptionMiddleware>(options);
+        }
+    }
+}

--- a/HiperServiceResultHandler/ResponseMessageGenerator.cs
+++ b/HiperServiceResultHandler/ResponseMessageGenerator.cs
@@ -6,16 +6,15 @@ namespace HiperServiceResultHandler
 {
     public static class ResponseMessageGenerator
     {
-
         public static OkObjectResult Result<T>(this ControllerBase controller, T data, string userMessage = null, string userMessageCode = null)
         {
             return Result(data, userMessage, userMessageCode);
         }
+
         public static OkObjectResult Result(this ControllerBase controller, object data, string userMessage, string userMessageCode = null)
         {
             return Result(data, userMessage, userMessageCode);
         }
-
 
         public static OkObjectResult Result(Object data, string userMessage, string userMessageCode = null, int? errorCode = null, string message = null, Exception exception = null)
         {
@@ -27,8 +26,8 @@ namespace HiperServiceResultHandler
                 ErrorCode = errorCode ?? 0,
                 Message = message,
                 Exception = exception?.ToString()
-
             };
+            
             if (errorCode.HasValue || !string.IsNullOrEmpty(message) || exception != null)
             {
                 result.IsSuccessful = false;
@@ -37,8 +36,8 @@ namespace HiperServiceResultHandler
             {
                 result.IsSuccessful = true;
             }
+
             return new OkObjectResult(result);
         }
-
     }
 }

--- a/HiperServiceResultHandler/ServiceExceptions.cs
+++ b/HiperServiceResultHandler/ServiceExceptions.cs
@@ -10,6 +10,7 @@ namespace HiperServiceResultHandler
             ErrorCode = errorCode;
             UserMessageCode = userMessageCode;
         }
+
         public ServiceException(string userMessage, int errorCode, string userMessageCode = null, string message = null, Exception innerException = null) : base(message, innerException)
         {
             UserMessage = userMessage;
@@ -18,8 +19,9 @@ namespace HiperServiceResultHandler
         }
 
         public string UserMessage { get; set; }
-        public int ErrorCode { get; set; }
-        public string UserMessageCode { get; set; }
 
+        public int ErrorCode { get; set; }
+
+        public string UserMessageCode { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# MicroServiceResultHandler
+# HiperServiceResultHandler
+
+Simple micro-service result handler.
+Provides a framework to streamline communication between front-end end-points (public API) and internal microservices for .NET&nbsp;Core.
+
+## Install
+
+Should be installed both on the public-facing APIs and the internal microservices:
+
+```
+Install-Package HiperServiceResultHandler
+```
+
+## Framework setup
+
+Communication between front-end and back-end relies on the `ApiResultMessage` class. The class encapsulates data returned by the back-end, but can also contain details about the error in case the microservice raises an exception.
+
+```mermaid
+sequenceDiagram
+    Client->>Public API: Request
+    Public API->>Microservice: Internal request
+    alt Request successful
+        Microservice->>Public API: ApiResultMessage<T>
+        Public API->>Client: T
+    else Request fails
+        Microservice->>Public API: ApiResultMessage
+        Public API->>Client: Error details
+    end
+```
+
+### Middleware
+
+Both microservice and public API servers must install the middleware that handles the transfer of exceptions.
+In the microservice server, add the following middleware during startup:
+
+```
+app.ConfigureServiceExceptionHandler();
+```
+
+While on the public API server, the following:
+
+```
+app.ConfigurePublicServiceExceptionHandler();
+```
+
+If running the public API in development mode, you may pass in an options object in order to have publicly-readable exceptions in your output:
+
+```
+app.ConfigurePublicServiceExceptionHandler(new PublicExceptionMiddleware.Options { DevelopmentMode = true });
+```
+
+### Microservice output
+
+In order to prepare your microservice output, you can package up data using extension methods on `ControllerBase`:
+
+```
+[HttpGet]
+public ActionResult Test() {
+    return Result("My test data");
+}
+```
+
+or any custom type of data:
+
+```
+[HttpGet]
+public ActionResult Test() {
+    return Result(new {
+        FieldA = "Test",
+        FieldB = 123,
+        FieldC = 12.12m
+    });
+}
+```
+
+The examples above produce JSON-serialized outputs following the structure of the `ApiResultMessage` class.
+
+If, at any point, an exception is raised in your microservice code, the error is packaged up into an `ApiResultMessage` result and passed as result.
+If you want to pass more information about the error to your public API, you can throw a `ServiceException`, which contains additional fields that can be used to specify details about the error.
+
+### HttpClient communication
+
+When retrieving data from a microservice, you may use one of the generic extensions methods from the `HttpClientExtensions` class, for instance:
+
+```
+var http = new HttpClient();
+var s = await http.GetAsync<string>("https://host/end-point");
+```
+
+This call expects that the target microservice will return a serialized instance of `ApiResultMessage<string>`.
+If everything works as intended, the `GetAsync` call will return the string, otherwise an exception is raised, mimicking the error on the microservice-side.
+
+Several `HttpClient` extensions are provided, for different HTTP methods with or without payload (e.g., `PostAsJsonAsync`, `PutAsJsonAsync`, `DeleteAsync`, etc.).


### PR DESCRIPTION
A set of common HttpClient extensions have been added, that allow clients to quickly deserialize data packaged up into an `ApiResultMessage` object. An additional middleware has been added, intended for public-facing APIs, that handles `ServiceException` instances like `ExceptionMiddleware` does for microservices, making the **HiperServiceResultHandler** package useful on both sides of the setup.

Added a brief readme with an overview.

A set of tests has been added to test the full setup:
- Client `HiperServiceResultHandler.Test.Runner`
- Public API `HiperServiceResultHandler.Test.Server`
- Back-end microservice: `HiperServiceResultHandler.Test.Service`